### PR TITLE
Add container log request equivalent to KubeControllerManagerLogs

### DIFF
--- a/cluster-mapping.json
+++ b/cluster-mapping.json
@@ -1,3 +1,7 @@
 [
-    ["4.0.0", "config_default.json"]
+    ["4.0.0", "config_default.json"],
+    ["4.17.0-0", "config_validation.json"],
+    ["4.17.0", "config_default.json"],
+    ["4.18.0-0", "config_validation.json"],
+    ["4.18.0", "config_default.json"]
 ]

--- a/remote_configurations/config_validation.json
+++ b/remote_configurations/config_validation.json
@@ -1,0 +1,23 @@
+{
+  "conditional_gathering_rules": [
+    "AlertmanagerFailedReload",
+    "AlertmanagerFailedToSendAlerts",
+    "APIRemovedInNextEUSReleaseInUse",
+    "KubePodCrashLooping",
+    "KubePodNotReady",
+    "PrometheusOperatorSyncFailed",
+    "PrometheusTargetSyncFailure",
+    "SamplesImagestreamImportFailing",
+    "ThanosRuleQueueIsDroppingAlerts"
+  ],
+  "container_logs": [
+    {
+      "namespace": "openshift-kube-controller-manager",
+      "pod_name_regex": "kube-controller-manager.*",
+      "messages": [
+        "Internal error occurred: error resolving resource",
+        "syncing garbage collector with updated resources from discovery"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
The container log request is limited to pre-release versions of OCP 4.17 and OCP 4.18 only.