### PR TITLE
Enable 'pretty-format-json' pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,3 +4,8 @@ repos:
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
+      - id: pretty-format-json
+        args:
+          - --indent=2
+          - --autofix
+        exclude: cluster_version_mapping.json

--- a/conditional_gathering_rules/APIRemovedInNextEUSReleaseInUse.json
+++ b/conditional_gathering_rules/APIRemovedInNextEUSReleaseInUse.json
@@ -1,10 +1,10 @@
 {
   "conditions": [
     {
-      "type": "alert_is_firing",
       "alert": {
         "name": "APIRemovedInNextEUSReleaseInUse"
-      }
+      },
+      "type": "alert_is_firing"
     }
   ],
   "gathering_functions": {

--- a/conditional_gathering_rules/AlertmanagerFailedReload.json
+++ b/conditional_gathering_rules/AlertmanagerFailedReload.json
@@ -1,10 +1,10 @@
 {
   "conditions": [
     {
-      "type": "alert_is_firing",
       "alert": {
         "name": "AlertmanagerFailedReload"
-      }
+      },
+      "type": "alert_is_firing"
     }
   ],
   "gathering_functions": {

--- a/conditional_gathering_rules/AlertmanagerFailedToSendAlerts.json
+++ b/conditional_gathering_rules/AlertmanagerFailedToSendAlerts.json
@@ -1,17 +1,17 @@
 {
   "conditions": [
     {
-      "type": "alert_is_firing",
       "alert": {
         "name": "AlertmanagerFailedToSendAlerts"
-      }
+      },
+      "type": "alert_is_firing"
     }
   ],
   "gathering_functions": {
     "containers_logs": {
       "alert_name": "AlertmanagerFailedToSendAlerts",
-      "tail_lines": 50,
-      "container": "alertmanager"
+      "container": "alertmanager",
+      "tail_lines": 50
     }
   }
 }

--- a/conditional_gathering_rules/KubePodCrashLooping.json
+++ b/conditional_gathering_rules/KubePodCrashLooping.json
@@ -1,17 +1,17 @@
 {
   "conditions": [
     {
-      "type": "alert_is_firing",
       "alert": {
         "name": "KubePodCrashLooping"
-      }
+      },
+      "type": "alert_is_firing"
     }
   ],
   "gathering_functions": {
     "containers_logs": {
       "alert_name": "KubePodCrashLooping",
-      "tail_lines": 20,
-      "previous": true
+      "previous": true,
+      "tail_lines": 20
     }
   }
 }

--- a/conditional_gathering_rules/KubePodNotReady.json
+++ b/conditional_gathering_rules/KubePodNotReady.json
@@ -1,10 +1,10 @@
 {
   "conditions": [
     {
-      "type": "alert_is_firing",
       "alert": {
         "name": "KubePodNotReady"
-      }
+      },
+      "type": "alert_is_firing"
     }
   ],
   "gathering_functions": {

--- a/conditional_gathering_rules/PrometheusOperatorSyncFailed.json
+++ b/conditional_gathering_rules/PrometheusOperatorSyncFailed.json
@@ -1,17 +1,17 @@
 {
   "conditions": [
     {
-      "type": "alert_is_firing",
       "alert": {
         "name": "PrometheusOperatorSyncFailed"
-      }
+      },
+      "type": "alert_is_firing"
     }
   ],
   "gathering_functions": {
     "containers_logs": {
       "alert_name": "PrometheusOperatorSyncFailed",
-      "tail_lines": 50,
-      "container": "prometheus-operator"
+      "container": "prometheus-operator",
+      "tail_lines": 50
     }
   }
 }

--- a/conditional_gathering_rules/PrometheusTargetSyncFailure.json
+++ b/conditional_gathering_rules/PrometheusTargetSyncFailure.json
@@ -1,10 +1,10 @@
 {
   "conditions": [
     {
-      "type": "alert_is_firing",
       "alert": {
         "name": "PrometheusTargetSyncFailure"
-      }
+      },
+      "type": "alert_is_firing"
     }
   ],
   "gathering_functions": {

--- a/conditional_gathering_rules/SamplesImagestreamImportFailing.json
+++ b/conditional_gathering_rules/SamplesImagestreamImportFailing.json
@@ -1,19 +1,19 @@
 {
   "conditions": [
     {
-      "type": "alert_is_firing",
       "alert": {
         "name": "SamplesImagestreamImportFailing"
-      }
+      },
+      "type": "alert_is_firing"
     }
   ],
   "gathering_functions": {
+    "image_streams_of_namespace": {
+      "namespace": "openshift-cluster-samples-operator"
+    },
     "logs_of_namespace": {
       "namespace": "openshift-cluster-samples-operator",
       "tail_lines": 100
-    },
-    "image_streams_of_namespace": {
-      "namespace": "openshift-cluster-samples-operator"
     }
   }
 }

--- a/conditional_gathering_rules/ThanosRuleQueueIsDroppingAlerts.json
+++ b/conditional_gathering_rules/ThanosRuleQueueIsDroppingAlerts.json
@@ -1,10 +1,10 @@
 {
   "conditions": [
     {
-      "type": "alert_is_firing",
       "alert": {
         "name": "ThanosRuleQueueIsDroppingAlerts"
-      }
+      },
+      "type": "alert_is_firing"
     }
   ],
   "gathering_functions": {

--- a/container_log_requests/manual/kube_controller_manager_logs_gatherer.json
+++ b/container_log_requests/manual/kube_controller_manager_logs_gatherer.json
@@ -1,8 +1,8 @@
 {
-  "namespace": "openshift-kube-controller-manager",
-  "pod_name_regex": "kube-controller-manager.*",
   "messages": [
     "Internal error occurred: error resolving resource",
     "syncing garbage collector with updated resources from discovery"
-  ]
+  ],
+  "namespace": "openshift-kube-controller-manager",
+  "pod_name_regex": "kube-controller-manager.*"
 }

--- a/schemas/cluster_version_mapping.schema.json
+++ b/schemas/cluster_version_mapping.schema.json
@@ -1,35 +1,47 @@
 {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "cluster_version_mapping.schema.json",
-    "title": "Cluster Version Mapping for Rapid Recommendations",
-    "descriptions": "A data structure used by the Insights Operator Gathering Conditions Service v2 API to map Insights Operator versions to specific remote configurations for those versions.",
-    "examples": [
-        [
-            ["1.0.0", "safe_1.json"],
-            ["2.0.0-0", "experimental_1.json"],
-            ["2.0.0", "safe_2.json"],
-            ["3.0.0-0", "experimental_2.json"]
-        ]
+  "$id": "cluster_version_mapping.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "A sequence of pairs specifying OpenShift version intervals and specific remote configurations to be used for those intervals. The sequence of pairs in the array must specify a strictly increasing sequence of versions (this requirement is not imposed by the schema itself). An interval is defined by two consecutive pairs.",
+  "descriptions": "A data structure used by the Insights Operator Gathering Conditions Service v2 API to map Insights Operator versions to specific remote configurations for those versions.",
+  "examples": [
+    [
+      [
+        "1.0.0",
+        "safe_1.json"
+      ],
+      [
+        "2.0.0-0",
+        "experimental_1.json"
+      ],
+      [
+        "2.0.0",
+        "safe_2.json"
+      ],
+      [
+        "3.0.0-0",
+        "experimental_2.json"
+      ]
+    ]
+  ],
+  "items": {
+    "description": "A pair specifying the start of an OpenShift version interval and a specific remote configuration to be used for a version interval that starts at the version (inclusive) and ends at the version specified by the next pair (non-inclusive). The interval specified by the last pair is unbounded.",
+    "maxItems": 2,
+    "minItems": 2,
+    "prefixItems": [
+      {
+        "description": "A semantic version string that specifies the start of a version interval (inclusive).",
+        "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
+        "type": "string"
+      },
+      {
+        "description": "The file name of a pre-generated remote configuration that the Insights Operator Conditional Gathering Service v2 API will return for versions in the interval represented by the pair.",
+        "type": "string"
+      }
     ],
-    "type": "array",
-    "description": "A sequence of pairs specifying OpenShift version intervals and specific remote configurations to be used for those intervals. The sequence of pairs in the array must specify a strictly increasing sequence of versions (this requirement is not imposed by the schema itself). An interval is defined by two consecutive pairs.",
-    "uniqueItems": true,
-    "items": {
-        "type": "array",
-        "description": "A pair specifying the start of an OpenShift version interval and a specific remote configuration to be used for a version interval that starts at the version (inclusive) and ends at the version specified by the next pair (non-inclusive). The interval specified by the last pair is unbounded.",
-        "minItems": 2,
-        "maxItems": 2,
-        "prefixItems": [
-            {
-                "type": "string",
-                "description": "A semantic version string that specifies the start of a version interval (inclusive).",
-                "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
-            },
-            {
-                "type": "string",
-                "description": "The file name of a pre-generated remote configuration that the Insights Operator Conditional Gathering Service v2 API will return for versions in the interval represented by the pair."
-            }
-        ]
-    },
-    "minItems": 1
+    "type": "array"
+  },
+  "minItems": 1,
+  "title": "Cluster Version Mapping for Rapid Recommendations",
+  "type": "array",
+  "uniqueItems": true
 }


### PR DESCRIPTION
I eventually gave up on custom key ordering:

1. Having one common configuration for all the different files would be tricky.
2. Container log requests are expected to be generated by automated tools from custom data representations (e.g. pod log parsers used by rules). Every data requestor would have to replicate the custom formatting. 

The only file exempted from the standard formatting remains `cluster_version_mapping.json`. This file is expected to be edited only manually. Tools will only need to read and copy the file. 