### PR TITLE
Adding Json shcema for remote_configuration_v2_template

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ details).
     [Insights Operator Gathering Conditions Service](https://github.com/redhatinsights/insights-operator-gathering-conditions-service)
     for the `v2` API.
 * `templates_v2/remote_configurations/*.json`
-  [TODO: schema link]
+  [[schema](https://github.com/RedHatInsights/insights-operator-gathering-conditions/blob/main/schemas/remote_configuration_v2_template.schema.json)]
   * Templates for remote configurations served by the `v2` API of the
     [Insights Operator Gathering Conditions Service](https://github.com/redhatinsights/insights-operator-gathering-conditions-service).
 

--- a/schemas/remote_configuration_v2_template.schema.json
+++ b/schemas/remote_configuration_v2_template.schema.json
@@ -5,29 +5,29 @@
   "description": "Config template files stored as object which contain list of conditional gathering rules and list of container logs",
   "example": {
     "conditional_gathering_rules": [
-      "conditional_gathering_rules/rule1.json",
-      "conditional_gathering_rules/rule2.json",
-      "conditional_gathering_rules/subdir/rule3.json"
+      "conditional_gathering_rules/*.json",
+      "conditional_gathering_rules/rule1.json"
     ],
     "container_logs": [
+      "container_log_requests/ccx-rules-ocp/*.json",
       "container_log_requests/manual/kube_controller_manager_logs_gatherer.json"
     ]
   },
   "properties": {
     "conditional_gathering_rules": {
-      "description": "Array of paths to conditional gathering rules",
+      "description": "Array of glob patterns matching conditional gathering rules to be included in the configuration file. The glob patterns are relative to the source data (repository) root.",
       "items": {
         "description": "Path to conditional gathering rule",
-        "pattern": "^conditional_gathering_rules\\/(.+\\/)*[^\\/]+\\.json$",
+        "pattern": "^conditional_gathering_rules\\/[^/]+\\.json$",
         "type": "string"
       },
       "type": "array"
     },
     "container_logs": {
-      "description": "Array of paths to container logs",
+      "description": "Array of glob patterns matching conditional gathering rules to be included in the configuration file. The glob patterns are relative to the source data (repository) root.",
       "items": {
         "description": "Path to container logs gatherer",
-        "pattern": "^container_log_requests/manual\\/(.+\\/)*[^\\/]+\\.json$",
+        "pattern": "^container_log_requests/[^/]+/[^/]+\\.json$",
         "type": "string"
       },
       "type": "array"

--- a/schemas/remote_configuration_v2_template.schema.json
+++ b/schemas/remote_configuration_v2_template.schema.json
@@ -1,0 +1,41 @@
+{
+  "$id": "remote_configuration_v2_template",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Config template files stored as object which contain list of conditional gathering rules and list of container logs",
+  "example": {
+    "conditional_gathering_rules": [
+      "conditional_gathering_rules/rule1.json",
+      "conditional_gathering_rules/rule2.json",
+      "conditional_gathering_rules/subdir/rule3.json"
+    ],
+    "container_logs": [
+      "container_log_requests/manual/kube_controller_manager_logs_gatherer.json"
+    ]
+  },
+  "properties": {
+    "conditional_gathering_rules": {
+      "description": "Array of paths to conditional gathering rules",
+      "items": {
+        "description": "Path to conditional gathering rule",
+        "pattern": "^conditional_gathering_rules\\/(.+\\/)*[^\\/]+\\.json$",
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "container_logs": {
+      "description": "Array of paths to container logs",
+      "items": {
+        "description": "Path to container logs gatherer",
+        "pattern": "^container_log_requests/manual\\/(.+\\/)*[^\\/]+\\.json$",
+        "type": "string"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "conditional_gathering_rules",
+    "container_logs"
+  ],
+  "type": "object"
+}


### PR DESCRIPTION
Adding json schema for remote_configuration_v2_template

@jholecek-rh I'm not sure if it is desired that conditional_gathering_rules could be stored in sub-directories and if the container_logs should be stored only under the manual sub-directory let me know if i should change something