### PR TITLE
[INSIGHTOCP-2010] Fix namespace names in happy day test data

### DIFF
--- a/tests/build_tool/valid_comprehensive/expected/v1/rules.json
+++ b/tests/build_tool/valid_comprehensive/expected/v1/rules.json
@@ -11,7 +11,7 @@
       ],
       "gathering_functions": {
         "logs_of_namespace": {
-          "namespace": "sample_a1",
+          "namespace": "openshift-sample-a1",
           "tail_lines": 100
         }
       }
@@ -27,7 +27,7 @@
       ],
       "gathering_functions": {
         "logs_of_namespace": {
-          "namespace": "sample_a2",
+          "namespace": "openshift-sample-a2",
           "tail_lines": 100
         }
       }
@@ -43,7 +43,7 @@
       ],
       "gathering_functions": {
         "logs_of_namespace": {
-          "namespace": "extra",
+          "namespace": "openshift-extra",
           "tail_lines": 100
         }
       }

--- a/tests/build_tool/valid_comprehensive/expected/v2/remote_configurations/config_all_container_logs.json
+++ b/tests/build_tool/valid_comprehensive/expected/v2/remote_configurations/config_all_container_logs.json
@@ -6,7 +6,7 @@
         "sample message 1-1",
         "sample message 1-2"
       ],
-      "namespace": "sample-request-1",
+      "namespace": "openshift-sample-request-1",
       "pod_name_regex": "pod-prefix-1-.*"
     },
     {
@@ -14,7 +14,7 @@
         "sample message 2-1",
         "sample message 2-2"
       ],
-      "namespace": "sample-request-2",
+      "namespace": "openshift-sample-request-2",
       "pod_name_regex": "pod-prefix-2-.*"
     },
     {
@@ -22,7 +22,7 @@
         "sample message 1-1",
         "sample message 1-2"
       ],
-      "namespace": "sample-request-1",
+      "namespace": "openshift-sample-request-1",
       "pod_name_regex": "pod-prefix-1-.*"
     },
     {
@@ -30,7 +30,7 @@
         "sample message 3-1",
         "sample message 3-2"
       ],
-      "namespace": "sample-request-3",
+      "namespace": "openshift-sample-request-3",
       "pod_name_regex": "pod-prefix-3-.*"
     },
     {
@@ -38,7 +38,7 @@
         "sample message 4-1",
         "sample message 4-2"
       ],
-      "namespace": "sample-request-4",
+      "namespace": "openshift-sample-request-4",
       "pod_name_regex": "pod-prefix-4-.*"
     }
   ],

--- a/tests/build_tool/valid_comprehensive/expected/v2/remote_configurations/config_all_gathering_rules.json
+++ b/tests/build_tool/valid_comprehensive/expected/v2/remote_configurations/config_all_gathering_rules.json
@@ -11,7 +11,7 @@
       ],
       "gathering_functions": {
         "logs_of_namespace": {
-          "namespace": "extra",
+          "namespace": "openshift-extra",
           "tail_lines": 100
         }
       }
@@ -27,7 +27,7 @@
       ],
       "gathering_functions": {
         "logs_of_namespace": {
-          "namespace": "sample_a1",
+          "namespace": "openshift-sample-a1",
           "tail_lines": 100
         }
       }
@@ -43,7 +43,7 @@
       ],
       "gathering_functions": {
         "logs_of_namespace": {
-          "namespace": "sample_a2",
+          "namespace": "openshift-sample-a2",
           "tail_lines": 100
         }
       }
@@ -59,7 +59,7 @@
       ],
       "gathering_functions": {
         "logs_of_namespace": {
-          "namespace": "sample_b1",
+          "namespace": "openshift-sample-b1",
           "tail_lines": 100
         }
       }
@@ -75,7 +75,7 @@
       ],
       "gathering_functions": {
         "logs_of_namespace": {
-          "namespace": "sample_b2",
+          "namespace": "openshift-sample-b2",
           "tail_lines": 100
         }
       }

--- a/tests/build_tool/valid_comprehensive/expected/v2/remote_configurations/config_duplicates.json
+++ b/tests/build_tool/valid_comprehensive/expected/v2/remote_configurations/config_duplicates.json
@@ -11,7 +11,7 @@
       ],
       "gathering_functions": {
         "logs_of_namespace": {
-          "namespace": "extra",
+          "namespace": "openshift-extra",
           "tail_lines": 100
         }
       }
@@ -23,7 +23,7 @@
         "sample message 1-1",
         "sample message 1-2"
       ],
-      "namespace": "sample-request-1",
+      "namespace": "openshift-sample-request-1",
       "pod_name_regex": "pod-prefix-1-.*"
     },
     {
@@ -31,7 +31,7 @@
         "sample message 2-1",
         "sample message 2-2"
       ],
-      "namespace": "sample-request-2",
+      "namespace": "openshift-sample-request-2",
       "pod_name_regex": "pod-prefix-2-.*"
     }
   ],

--- a/tests/build_tool/valid_comprehensive/expected/v2/remote_configurations/config_multiple_patterns.json
+++ b/tests/build_tool/valid_comprehensive/expected/v2/remote_configurations/config_multiple_patterns.json
@@ -11,7 +11,7 @@
       ],
       "gathering_functions": {
         "logs_of_namespace": {
-          "namespace": "sample_b1",
+          "namespace": "openshift-sample-b1",
           "tail_lines": 100
         }
       }
@@ -27,7 +27,7 @@
       ],
       "gathering_functions": {
         "logs_of_namespace": {
-          "namespace": "sample_b2",
+          "namespace": "openshift-sample-b2",
           "tail_lines": 100
         }
       }
@@ -43,7 +43,7 @@
       ],
       "gathering_functions": {
         "logs_of_namespace": {
-          "namespace": "extra",
+          "namespace": "openshift-extra",
           "tail_lines": 100
         }
       }
@@ -55,7 +55,7 @@
         "sample message 1-1",
         "sample message 1-2"
       ],
-      "namespace": "sample-request-1",
+      "namespace": "openshift-sample-request-1",
       "pod_name_regex": "pod-prefix-1-.*"
     },
     {
@@ -63,7 +63,7 @@
         "sample message 2-1",
         "sample message 2-2"
       ],
-      "namespace": "sample-request-2",
+      "namespace": "openshift-sample-request-2",
       "pod_name_regex": "pod-prefix-2-.*"
     },
     {
@@ -71,7 +71,7 @@
         "sample message 1-1",
         "sample message 1-2"
       ],
-      "namespace": "sample-request-1",
+      "namespace": "openshift-sample-request-1",
       "pod_name_regex": "pod-prefix-1-.*"
     },
     {
@@ -79,7 +79,7 @@
         "sample message 3-1",
         "sample message 3-2"
       ],
-      "namespace": "sample-request-3",
+      "namespace": "openshift-sample-request-3",
       "pod_name_regex": "pod-prefix-3-.*"
     }
   ],

--- a/tests/build_tool/valid_comprehensive/src/conditional_gathering_rules/extra.json
+++ b/tests/build_tool/valid_comprehensive/src/conditional_gathering_rules/extra.json
@@ -9,7 +9,7 @@
   ],
   "gathering_functions": {
     "logs_of_namespace": {
-      "namespace": "extra",
+      "namespace": "openshift-extra",
       "tail_lines": 100
     }
   }

--- a/tests/build_tool/valid_comprehensive/src/conditional_gathering_rules/sample_a1.json
+++ b/tests/build_tool/valid_comprehensive/src/conditional_gathering_rules/sample_a1.json
@@ -9,7 +9,7 @@
   ],
   "gathering_functions": {
     "logs_of_namespace": {
-      "namespace": "sample_a1",
+      "namespace": "openshift-sample-a1",
       "tail_lines": 100
     }
   }

--- a/tests/build_tool/valid_comprehensive/src/conditional_gathering_rules/sample_a2.json
+++ b/tests/build_tool/valid_comprehensive/src/conditional_gathering_rules/sample_a2.json
@@ -9,7 +9,7 @@
   ],
   "gathering_functions": {
     "logs_of_namespace": {
-      "namespace": "sample_a2",
+      "namespace": "openshift-sample-a2",
       "tail_lines": 100
     }
   }

--- a/tests/build_tool/valid_comprehensive/src/conditional_gathering_rules/sample_b1.json
+++ b/tests/build_tool/valid_comprehensive/src/conditional_gathering_rules/sample_b1.json
@@ -9,7 +9,7 @@
   ],
   "gathering_functions": {
     "logs_of_namespace": {
-      "namespace": "sample_b1",
+      "namespace": "openshift-sample-b1",
       "tail_lines": 100
     }
   }

--- a/tests/build_tool/valid_comprehensive/src/conditional_gathering_rules/sample_b2.json
+++ b/tests/build_tool/valid_comprehensive/src/conditional_gathering_rules/sample_b2.json
@@ -9,7 +9,7 @@
   ],
   "gathering_functions": {
     "logs_of_namespace": {
-      "namespace": "sample_b2",
+      "namespace": "openshift-sample-b2",
       "tail_lines": 100
     }
   }

--- a/tests/build_tool/valid_comprehensive/src/container_log_requests/team1/sample_request_1.json
+++ b/tests/build_tool/valid_comprehensive/src/container_log_requests/team1/sample_request_1.json
@@ -3,6 +3,6 @@
     "sample message 1-1",
     "sample message 1-2"
   ],
-  "namespace": "sample-request-1",
+  "namespace": "openshift-sample-request-1",
   "pod_name_regex": "pod-prefix-1-.*"
 }

--- a/tests/build_tool/valid_comprehensive/src/container_log_requests/team1/sample_request_2.json
+++ b/tests/build_tool/valid_comprehensive/src/container_log_requests/team1/sample_request_2.json
@@ -3,6 +3,6 @@
     "sample message 2-1",
     "sample message 2-2"
   ],
-  "namespace": "sample-request-2",
+  "namespace": "openshift-sample-request-2",
   "pod_name_regex": "pod-prefix-2-.*"
 }

--- a/tests/build_tool/valid_comprehensive/src/container_log_requests/team2/sample_request_1.json
+++ b/tests/build_tool/valid_comprehensive/src/container_log_requests/team2/sample_request_1.json
@@ -3,6 +3,6 @@
     "sample message 1-1",
     "sample message 1-2"
   ],
-  "namespace": "sample-request-1",
+  "namespace": "openshift-sample-request-1",
   "pod_name_regex": "pod-prefix-1-.*"
 }

--- a/tests/build_tool/valid_comprehensive/src/container_log_requests/team2/sample_request_3.json
+++ b/tests/build_tool/valid_comprehensive/src/container_log_requests/team2/sample_request_3.json
@@ -3,6 +3,6 @@
     "sample message 3-1",
     "sample message 3-2"
   ],
-  "namespace": "sample-request-3",
+  "namespace": "openshift-sample-request-3",
   "pod_name_regex": "pod-prefix-3-.*"
 }

--- a/tests/build_tool/valid_comprehensive/src/container_log_requests/team3/sample_request_4.json
+++ b/tests/build_tool/valid_comprehensive/src/container_log_requests/team3/sample_request_4.json
@@ -3,6 +3,6 @@
     "sample message 4-1",
     "sample message 4-2"
   ],
-  "namespace": "sample-request-4",
+  "namespace": "openshift-sample-request-4",
   "pod_name_regex": "pod-prefix-4-.*"
 }


### PR DESCRIPTION
We will be extending the build tool to verify that generated configuration files match their schemas. The schemas for both conditional gathering rules and container log requests require that namespace names are valid Kubernetes namespace names with the `openshift-` prefix.

This commit fixes existing happy day test data to meet this requirement.

The generated `v1/rules.json` matches its schema in this commit.

Some generated `v2/remote_configurations/*.json` still do not match their schema in this commit. This issue will be fixed separately.