### PR TITLE
Validate regular expressions in config files generated by the build tool

### DIFF
--- a/tests/build_tool/invalid_message_filters/expected_stderr.txt
+++ b/tests/build_tool/invalid_message_filters/expected_stderr.txt
@@ -1,0 +1,3 @@
+v2/remote_configurations/config_default.json
+RegexValidationError: Message filters do not comprise a valid golang regular expression
+INVALID MESSAGE FILTER '['

--- a/tests/build_tool/invalid_message_filters/expected_stdout.txt
+++ b/tests/build_tool/invalid_message_filters/expected_stdout.txt
@@ -1,0 +1,1 @@
+RegexValidationError: Message filters do not comprise a valid golang regular expression

--- a/tests/build_tool/invalid_message_filters/src/conditional_gathering_rules/valid.json
+++ b/tests/build_tool/invalid_message_filters/src/conditional_gathering_rules/valid.json
@@ -1,0 +1,16 @@
+{
+  "conditions": [
+    {
+      "alert": {
+        "name": "KubePodCrashLooping"
+      },
+      "type": "alert_is_firing"
+    }
+  ],
+  "gathering_functions": {
+    "logs_of_namespace": {
+      "namespace": "openshift-sample-a2",
+      "tail_lines": 100
+    }
+  }
+}

--- a/tests/build_tool/invalid_message_filters/src/container_log_requests/sample_request_1.json
+++ b/tests/build_tool/invalid_message_filters/src/container_log_requests/sample_request_1.json
@@ -1,0 +1,8 @@
+{
+  "messages": [
+    "sample message 1-1",
+    "sample message 1-2"
+  ],
+  "namespace": "openshift-sample-request-1",
+  "pod_name_regex": "pod-prefix-1-.*"
+}

--- a/tests/build_tool/invalid_message_filters/src/container_log_requests/sample_request_2.json
+++ b/tests/build_tool/invalid_message_filters/src/container_log_requests/sample_request_2.json
@@ -1,0 +1,8 @@
+{
+  "messages": [
+    "sample message 2-1",
+    "INVALID MESSAGE FILTER '['"
+  ],
+  "namespace": "openshift-sample-request-2",
+  "pod_name_regex": "some-pod-.{5}"
+}

--- a/tests/build_tool/invalid_message_filters/src/templates_v1/rules.json
+++ b/tests/build_tool/invalid_message_filters/src/templates_v1/rules.json
@@ -1,0 +1,5 @@
+{
+  "rules": [
+    "conditional_gathering_rules/*.json"
+  ]
+}

--- a/tests/build_tool/invalid_message_filters/src/templates_v2/cluster_version_mapping.json
+++ b/tests/build_tool/invalid_message_filters/src/templates_v2/cluster_version_mapping.json
@@ -1,0 +1,3 @@
+[
+    ["4.0.0", "config_default.json"]
+]

--- a/tests/build_tool/invalid_message_filters/src/templates_v2/remote_configurations/config_default.json
+++ b/tests/build_tool/invalid_message_filters/src/templates_v2/remote_configurations/config_default.json
@@ -1,0 +1,8 @@
+{
+  "conditional_gathering_rules": [
+    "conditional_gathering_rules/valid.json"
+  ],
+  "container_logs": [
+    "container_log_requests/*.json"
+  ]
+}

--- a/tests/build_tool/invalid_pod_name_regex/expected_stderr.txt
+++ b/tests/build_tool/invalid_pod_name_regex/expected_stderr.txt
@@ -1,0 +1,3 @@
+v2/remote_configurations/config_default.json
+RegexValidationError: Invalid golang regular expression in '.container_logs[1].pod_name_regex'
+INVALID_REGEX_[

--- a/tests/build_tool/invalid_pod_name_regex/expected_stdout.txt
+++ b/tests/build_tool/invalid_pod_name_regex/expected_stdout.txt
@@ -1,0 +1,1 @@
+RegexValidationError: Invalid golang regular expression in '.container_logs[1].pod_name_regex'

--- a/tests/build_tool/invalid_pod_name_regex/src/conditional_gathering_rules/valid.json
+++ b/tests/build_tool/invalid_pod_name_regex/src/conditional_gathering_rules/valid.json
@@ -1,0 +1,16 @@
+{
+  "conditions": [
+    {
+      "alert": {
+        "name": "KubePodCrashLooping"
+      },
+      "type": "alert_is_firing"
+    }
+  ],
+  "gathering_functions": {
+    "logs_of_namespace": {
+      "namespace": "openshift-sample-a2",
+      "tail_lines": 100
+    }
+  }
+}

--- a/tests/build_tool/invalid_pod_name_regex/src/container_log_requests/sample_request_1.json
+++ b/tests/build_tool/invalid_pod_name_regex/src/container_log_requests/sample_request_1.json
@@ -1,0 +1,8 @@
+{
+  "messages": [
+    "sample message 1-1",
+    "sample message 1-2"
+  ],
+  "namespace": "openshift-sample-request-1",
+  "pod_name_regex": "pod-prefix-1-.*"
+}

--- a/tests/build_tool/invalid_pod_name_regex/src/container_log_requests/sample_request_2.json
+++ b/tests/build_tool/invalid_pod_name_regex/src/container_log_requests/sample_request_2.json
@@ -1,0 +1,8 @@
+{
+  "messages": [
+    "sample message 2-1",
+    "sample message 2-2"
+  ],
+  "namespace": "openshift-sample-request-2",
+  "pod_name_regex": "INVALID_REGEX_["
+}

--- a/tests/build_tool/invalid_pod_name_regex/src/templates_v1/rules.json
+++ b/tests/build_tool/invalid_pod_name_regex/src/templates_v1/rules.json
@@ -1,0 +1,5 @@
+{
+  "rules": [
+    "conditional_gathering_rules/*.json"
+  ]
+}

--- a/tests/build_tool/invalid_pod_name_regex/src/templates_v2/cluster_version_mapping.json
+++ b/tests/build_tool/invalid_pod_name_regex/src/templates_v2/cluster_version_mapping.json
@@ -1,0 +1,3 @@
+[
+    ["4.0.0", "config_default.json"]
+]

--- a/tests/build_tool/invalid_pod_name_regex/src/templates_v2/remote_configurations/config_default.json
+++ b/tests/build_tool/invalid_pod_name_regex/src/templates_v2/remote_configurations/config_default.json
@@ -1,0 +1,8 @@
+{
+  "conditional_gathering_rules": [
+    "conditional_gathering_rules/valid.json"
+  ],
+  "container_logs": [
+    "container_log_requests/*.json"
+  ]
+}


### PR DESCRIPTION
This PR adds the last missing validations to the build tool as outlined in the test plan.

The build tool performs the following validations now:

* `cluster_version_mapping.json` matches its schema
* Entries in `cluster_version_mapping.json` have strictly increasing versions using semantic versioning
* The first entry in `cluster_version_mapping.json` is smaller than or equal to `4.17.0-0`
* All remote configurations referenced in `cluster_version_mapping.json` exist
* For each generated remote configuration
   * The remote configuration matches its schema
   * All pod name regexes in the remote configuration are valid Go [regexp](https://pkg.go.dev/regexp) regular expressions
   * A regex that ORs all container log message filters in the remote configuration is a valid Go [regexp](https://pkg.go.dev/regexp) regular expression