### PR TITLE
[INSIGHTOCP-2121] Use relative paths to reference remote configurations in cluster_version_mapping.json

### DIFF
--- a/blueprints_v2/cluster_version_mapping.json
+++ b/blueprints_v2/cluster_version_mapping.json
@@ -1,7 +1,7 @@
 [
-    ["4.0.0", "config_default.json"],
-    ["4.17.0-0", "config_validation.json"],
-    ["4.17.0", "config_default.json"],
-    ["4.18.0-0", "config_validation.json"],
-    ["4.18.0", "config_default.json"]
+    ["4.0.0", "remote_configurations/config_default.json"],
+    ["4.17.0-0", "remote_configurations/config_validation.json"],
+    ["4.17.0", "remote_configurations/config_default.json"],
+    ["4.18.0-0", "remote_configurations/config_validation.json"],
+    ["4.18.0", "remote_configurations/config_default.json"]
 ]

--- a/build.py
+++ b/build.py
@@ -183,7 +183,8 @@ class RemoteConfigurations:
         logger.info("Writing v1 configs")
         outputdir_v1.mkdir(parents=True, exist_ok=True)
         for filename, config in self.configs_v1.items():
-            filepath = self._write_config(outputdir_v1, filename, config)
+            filepath = outputdir_v1 / filename
+            self._write_config(filepath, config)
             self._assert_json_schema(filepath, config, "remote_configuration_v1.schema.json")
 
     def _write_v2(self, outputdir_v2):
@@ -202,7 +203,8 @@ class RemoteConfigurations:
 
     def _write_v2_remote_configurations(self, remote_config_dir):
         for filename, config in self.configs_v2.items():
-            filepath = self._write_config(remote_config_dir, filename, config)
+            filepath = remote_config_dir / filename
+            self._write_config(filepath, config)
             self._assert_json_schema(filepath, config, "remote_configuration_v2.schema.json")
             self._assert_valid_pod_name_regexes(filepath, config)
             self._assert_valid_message_filters(filepath, config)
@@ -276,8 +278,7 @@ class RemoteConfigurations:
         return json.loads(path.read_text())
 
     @staticmethod
-    def _write_config(dirpath, filename, config):
-        filepath = dirpath / filename
+    def _write_config(filepath, config):
         logger.info(f"Writing config: {filepath}")
         filepath.write_text(json.dumps(config))
         return filepath

--- a/build.py
+++ b/build.py
@@ -78,6 +78,7 @@ class RemoteConfigurations:
 
         self.registry = Registry(retrieve=self._retrieve_schema)
         self.configs_v1 = {}
+        self.cluster_version_mapping = None
         self.configs_v2 = {}
 
         self._load_v1_config()
@@ -104,17 +105,62 @@ class RemoteConfigurations:
         }
 
     def _load_v2_configs(self):
-        blueprints_dir = self.sourcedir / "blueprints_v2" / "remote_configurations"
-        for blueprint_file in blueprints_dir.glob("*.json"):
-            logger.info(f"Building config from v2 blueprint: {blueprint_file}")
-            blueprint = self._load_json(blueprint_file)
-            self.configs_v2[blueprint_file.name] = {
+        blueprints_v2 = self.sourcedir / "blueprints_v2"
+        self._load_v2_cluster_version_mapping(blueprints_v2)
+        self._load_v2_remote_configurations(blueprints_v2)
+
+    def _load_v2_cluster_version_mapping(self, blueprints_v2):
+        filepath = self._get_v2_cluster_version_mapping_path(blueprints_v2)
+        logger.info(f"Loading cluster version mapping blueprint: {filepath}")
+        self.cluster_version_mapping = self._load_json(filepath)
+        self._assert_json_schema(
+            filepath, self.cluster_version_mapping, "cluster_version_mapping.schema.json"
+        )
+        self._assert_cluster_version_mapping_first_interval(filepath, self.cluster_version_mapping)
+        self._assert_cluster_version_mapping_order(filepath, self.cluster_version_mapping)
+
+    def _load_v2_remote_configurations(self, blueprints_v2):
+        for i, (_, filename) in enumerate(self.cluster_version_mapping):
+            # The same remote configuration file can be used for multiple version ranges.
+            if filename in self.configs_v2:
+                continue
+
+            blueprint_path = self._get_v2_remote_configuration_blueprint_path(
+                blueprints_v2, i, filename
+            )
+
+            logger.info(f"Building config from v2 blueprint: {blueprint_path}")
+            blueprint = self._load_json(blueprint_path)
+            self.configs_v2[filename] = {
                 "conditional_gathering_rules": self._expand_glob_list(
                     blueprint["conditional_gathering_rules"]
                 ),
                 "container_logs": self._expand_glob_list(blueprint["container_logs"]),
                 "version": self.version,
             }
+
+    @staticmethod
+    def _get_v2_cluster_version_mapping_path(root_v2):
+        return root_v2 / "cluster_version_mapping.json"
+
+    @staticmethod
+    def _get_v2_remote_configuration_path(root_v2, filename):
+        return root_v2 / "remote_configurations" / filename
+
+    def _get_v2_remote_configuration_blueprint_path(self, blueprints_v2, idx, filename):
+        blueprint_path = self._get_v2_remote_configuration_path(blueprints_v2, filename)
+
+        if not blueprint_path.is_file():
+            cluster_version_mapping_path = self._get_v2_cluster_version_mapping_path(blueprints_v2)
+            e = ClusterVersionMappingError(
+                f"'{filename}' does not reference a valid config at index {idx}: "
+                f"{cluster_version_mapping_path}; "
+                f"expected remote configuration blueprint path: {blueprint_path}"
+            )
+            logger.critical(f"❌ {e.__class__.__name__}: {e}")
+            raise (e)
+
+        return blueprint_path
 
     def _expand_glob_list(self, globs):
         loaded_paths = set()
@@ -149,7 +195,6 @@ class RemoteConfigurations:
 
     def _write_v2_cluster_version_mapping(self, outputdir_v2):
         srcpath = self.sourcedir / "blueprints_v2" / "cluster_version_mapping.json"
-        self._validate_cluster_version_mapping(srcpath)
         dstpath = outputdir_v2 / "cluster_version_mapping.json"
         logger.info(f"Writing cluster_version_mapping.json: {dstpath}")
         # preserve non-standard formatting of the file
@@ -161,13 +206,6 @@ class RemoteConfigurations:
             self._assert_json_schema(filepath, config, "remote_configuration_v2.schema.json")
             self._assert_valid_pod_name_regexes(filepath, config)
             self._assert_valid_message_filters(filepath, config)
-
-    def _validate_cluster_version_mapping(self, filepath):
-        content = self._load_json(filepath)
-        self._assert_json_schema(filepath, content, "cluster_version_mapping.schema.json")
-        self._assert_cluster_version_mapping_first_interval(filepath, content)
-        self._assert_cluster_version_mapping_order(filepath, content)
-        self._assert_cluster_version_mapping_configs_exist(filepath, content)
 
     def _assert_cluster_version_mapping_first_interval(self, filepath, content):
         first_version = content[0][0]
@@ -196,21 +234,6 @@ class RemoteConfigurations:
                 e.add_note(
                     "\nPairs in the cluster_version_mapping.json file "
                     "must have strictly increasing semantic versions."
-                )
-                logger.critical(f"❌ {e.__class__.__name__}: {e}")
-                raise (e)
-
-    def _assert_cluster_version_mapping_configs_exist(self, filepath, content):
-        for i, (_, config_name) in enumerate(content):
-            # If we loaded the config file, we trust ourselves that
-            # we would write the config or report another error.
-            if config_name not in self.configs_v2:
-                blueprint_path = (
-                    self.sourcedir / "blueprints_v2" / "remote_configurations" / config_name
-                )
-                e = ClusterVersionMappingError(
-                    f"'{config_name}' does not reference a valid config at index {i}: {filepath}; "
-                    f"expected config blueprint path: {blueprint_path}"
                 )
                 logger.critical(f"❌ {e.__class__.__name__}: {e}")
                 raise (e)

--- a/build.py
+++ b/build.py
@@ -144,20 +144,23 @@ class RemoteConfigurations:
         logger.info("Writing v2 configs")
         remote_config_dir = outputdir_v2 / "remote_configurations"
         remote_config_dir.mkdir(parents=True, exist_ok=True)
-        self._write_cluster_version_mapping(outputdir_v2)
-        for filename, config in self.configs_v2.items():
-            filepath = self._write_config(remote_config_dir, filename, config)
-            self._assert_json_schema(filepath, config, "remote_configuration_v2.schema.json")
-            self._assert_valid_pod_name_regexes(filepath, config)
-            self._assert_valid_message_filters(filepath, config)
+        self._write_v2_cluster_version_mapping(outputdir_v2)
+        self._write_v2_remote_configurations(remote_config_dir)
 
-    def _write_cluster_version_mapping(self, outputdir_v2):
+    def _write_v2_cluster_version_mapping(self, outputdir_v2):
         srcpath = self.sourcedir / "blueprints_v2" / "cluster_version_mapping.json"
         self._validate_cluster_version_mapping(srcpath)
         dstpath = outputdir_v2 / "cluster_version_mapping.json"
         logger.info(f"Writing cluster_version_mapping.json: {dstpath}")
         # preserve non-standard formatting of the file
         shutil.copy(srcpath, dstpath)
+
+    def _write_v2_remote_configurations(self, remote_config_dir):
+        for filename, config in self.configs_v2.items():
+            filepath = self._write_config(remote_config_dir, filename, config)
+            self._assert_json_schema(filepath, config, "remote_configuration_v2.schema.json")
+            self._assert_valid_pod_name_regexes(filepath, config)
+            self._assert_valid_message_filters(filepath, config)
 
     def _validate_cluster_version_mapping(self, filepath):
         content = self._load_json(filepath)

--- a/build.py
+++ b/build.py
@@ -133,28 +133,28 @@ class RemoteConfigurations:
         self._write_v1(outputdir / "v1")
         self._write_v2(outputdir / "v2")
 
-    def _write_v1(self, outputdir):
+    def _write_v1(self, outputdir_v1):
         logger.info("Writing v1 configs")
-        outputdir.mkdir(parents=True, exist_ok=True)
+        outputdir_v1.mkdir(parents=True, exist_ok=True)
         for filename, config in self.configs_v1.items():
-            filepath = self._write_config(outputdir, filename, config)
+            filepath = self._write_config(outputdir_v1, filename, config)
             self._assert_json_schema(filepath, config, "remote_configuration_v1.schema.json")
 
-    def _write_v2(self, outputdir):
+    def _write_v2(self, outputdir_v2):
         logger.info("Writing v2 configs")
-        remote_config_dir = outputdir / "remote_configurations"
+        remote_config_dir = outputdir_v2 / "remote_configurations"
         remote_config_dir.mkdir(parents=True, exist_ok=True)
-        self._write_cluster_version_mapping(outputdir)
+        self._write_cluster_version_mapping(outputdir_v2)
         for filename, config in self.configs_v2.items():
             filepath = self._write_config(remote_config_dir, filename, config)
             self._assert_json_schema(filepath, config, "remote_configuration_v2.schema.json")
             self._assert_valid_pod_name_regexes(filepath, config)
             self._assert_valid_message_filters(filepath, config)
 
-    def _write_cluster_version_mapping(self, outputdir):
+    def _write_cluster_version_mapping(self, outputdir_v2):
         srcpath = self.sourcedir / "blueprints_v2" / "cluster_version_mapping.json"
         self._validate_cluster_version_mapping(srcpath)
-        dstpath = outputdir / "cluster_version_mapping.json"
+        dstpath = outputdir_v2 / "cluster_version_mapping.json"
         logger.info(f"Writing cluster_version_mapping.json: {dstpath}")
         # preserve non-standard formatting of the file
         shutil.copy(srcpath, dstpath)
@@ -250,8 +250,8 @@ class RemoteConfigurations:
         return json.loads(path.read_text())
 
     @staticmethod
-    def _write_config(outputdir, filename, config):
-        filepath = outputdir / filename
+    def _write_config(dirpath, filename, config):
+        filepath = dirpath / filename
         logger.info(f"Writing config: {filepath}")
         filepath.write_text(json.dumps(config))
         return filepath

--- a/schemas/cluster_version_mapping.schema.json
+++ b/schemas/cluster_version_mapping.schema.json
@@ -1,7 +1,6 @@
 {
   "$id": "cluster_version_mapping.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "description": "A sequence of pairs specifying OpenShift version intervals and specific remote configurations to be used for those intervals. The sequence of pairs in the array must specify a strictly increasing sequence of versions (this requirement is not imposed by the schema itself). An interval is defined by two consecutive pairs.",
   "descriptions": "A data structure used by the Insights Operator Gathering Conditions Service v2 API to map Insights Operator versions to specific remote configurations for those versions.",
   "examples": [
     [
@@ -34,7 +33,7 @@
         "type": "string"
       },
       {
-        "description": "The file name of a pre-generated remote configuration that the Insights Operator Conditional Gathering Service v2 API will return for versions in the interval represented by the pair.",
+        "description": "A path to a remote configuration file that the Insights Operator Conditional Gathering Service v2 API will return for versions in the interval represented by the pair. The path must be relative to the location of the cluster_version_mapping.json file and must not point outside of its parent directory.",
         "type": "string"
       }
     ],

--- a/tests/build_tool/invalid_cluster_version_mapping_duplicate_version/src/blueprints_v2/cluster_version_mapping.json
+++ b/tests/build_tool/invalid_cluster_version_mapping_duplicate_version/src/blueprints_v2/cluster_version_mapping.json
@@ -1,5 +1,5 @@
 [
-    ["4.0.0", "config_default.json"],
-    ["4.2.0", "config_default.json"],
-    ["4.2.0", "config_other.json"]
+    ["4.0.0", "remote_configurations/config_default.json"],
+    ["4.2.0", "remote_configurations/config_default.json"],
+    ["4.2.0", "remote_configurations/config_other.json"]
 ]

--- a/tests/build_tool/invalid_cluster_version_mapping_minimal_version/src/blueprints_v2/cluster_version_mapping.json
+++ b/tests/build_tool/invalid_cluster_version_mapping_minimal_version/src/blueprints_v2/cluster_version_mapping.json
@@ -1,4 +1,4 @@
 [
-    ["4.18.0", "config_default.json"],
-    ["4.19.0", "config_default.json"]
+    ["4.18.0", "remote_configurations/config_default.json"],
+    ["4.19.0", "remote_configurations/config_default.json"]
 ]

--- a/tests/build_tool/invalid_cluster_version_mapping_no_such_config/expected_stderr.txt
+++ b/tests/build_tool/invalid_cluster_version_mapping_no_such_config/expected_stderr.txt
@@ -1,3 +1,3 @@
 src/blueprints_v2/cluster_version_mapping.json
 v2/remote_configurations/no_such_config.json
-ClusterVersionMappingError: 'no_such_config.json' does not reference a valid config at index 1
+ClusterVersionMappingError: 'remote_configurations/no_such_config.json' does not reference a valid config at index 1

--- a/tests/build_tool/invalid_cluster_version_mapping_no_such_config/expected_stdout.txt
+++ b/tests/build_tool/invalid_cluster_version_mapping_no_such_config/expected_stdout.txt
@@ -1,2 +1,2 @@
 v2/remote_configurations/no_such_config.json
-ClusterVersionMappingError: 'no_such_config.json' does not reference a valid config at index 1
+ClusterVersionMappingError: 'remote_configurations/no_such_config.json' does not reference a valid config at index 1

--- a/tests/build_tool/invalid_cluster_version_mapping_no_such_config/src/blueprints_v2/cluster_version_mapping.json
+++ b/tests/build_tool/invalid_cluster_version_mapping_no_such_config/src/blueprints_v2/cluster_version_mapping.json
@@ -1,4 +1,4 @@
 [
-    ["4.0.0", "config_default.json"],
-    ["4.11.0", "no_such_config.json"]
+    ["4.0.0", "remote_configurations/config_default.json"],
+    ["4.11.0", "remote_configurations/no_such_config.json"]
 ]

--- a/tests/build_tool/invalid_cluster_version_mapping_order/src/blueprints_v2/cluster_version_mapping.json
+++ b/tests/build_tool/invalid_cluster_version_mapping_order/src/blueprints_v2/cluster_version_mapping.json
@@ -1,5 +1,5 @@
 [
-    ["4.0.0", "config_default.json"],
-    ["4.11.0", "config_default.json"],
-    ["4.2.0", "config_default.json"]
+    ["4.0.0", "remote_configurations/config_default.json"],
+    ["4.11.0", "remote_configurations/config_default.json"],
+    ["4.2.0", "remote_configurations/config_default.json"]
 ]

--- a/tests/build_tool/invalid_cluster_version_mapping_schema/src/blueprints_v2/cluster_version_mapping.json
+++ b/tests/build_tool/invalid_cluster_version_mapping_schema/src/blueprints_v2/cluster_version_mapping.json
@@ -1,3 +1,3 @@
 [
-    ["INVALID VERSION", "config_default.json"]
+    ["INVALID VERSION", "remote_configurations/config_default.json"]
 ]

--- a/tests/build_tool/invalid_corrupted_v1_config_schema/src/blueprints_v2/cluster_version_mapping.json
+++ b/tests/build_tool/invalid_corrupted_v1_config_schema/src/blueprints_v2/cluster_version_mapping.json
@@ -1,3 +1,3 @@
 [
-    ["4.0.0", "config_default.json"]
+    ["4.0.0", "remote_configurations/config_default.json"]
 ]

--- a/tests/build_tool/invalid_corrupted_v2_config_schema/src/blueprints_v2/cluster_version_mapping.json
+++ b/tests/build_tool/invalid_corrupted_v2_config_schema/src/blueprints_v2/cluster_version_mapping.json
@@ -1,3 +1,3 @@
 [
-    ["4.0.0", "config_default.json"]
+    ["4.0.0", "remote_configurations/config_default.json"]
 ]

--- a/tests/build_tool/invalid_message_filters/src/blueprints_v2/cluster_version_mapping.json
+++ b/tests/build_tool/invalid_message_filters/src/blueprints_v2/cluster_version_mapping.json
@@ -1,3 +1,3 @@
 [
-    ["4.0.0", "config_default.json"]
+    ["4.0.0", "remote_configurations/config_default.json"]
 ]

--- a/tests/build_tool/invalid_pod_name_regex/src/blueprints_v2/cluster_version_mapping.json
+++ b/tests/build_tool/invalid_pod_name_regex/src/blueprints_v2/cluster_version_mapping.json
@@ -1,3 +1,3 @@
 [
-    ["4.0.0", "config_default.json"]
+    ["4.0.0", "remote_configurations/config_default.json"]
 ]

--- a/tests/build_tool/invalid_v1_config_fails_schema_validation/src/blueprints_v2/cluster_version_mapping.json
+++ b/tests/build_tool/invalid_v1_config_fails_schema_validation/src/blueprints_v2/cluster_version_mapping.json
@@ -1,3 +1,3 @@
 [
-    ["4.0.0", "config_default.json"]
+    ["4.0.0", "remote_configurations/config_default.json"]
 ]

--- a/tests/build_tool/invalid_v2_config_fails_schema_validation/src/blueprints_v2/cluster_version_mapping.json
+++ b/tests/build_tool/invalid_v2_config_fails_schema_validation/src/blueprints_v2/cluster_version_mapping.json
@@ -1,3 +1,3 @@
 [
-    ["4.0.0", "config_default.json"]
+    ["4.0.0", "remote_configurations/config_default.json"]
 ]

--- a/tests/build_tool/valid_comprehensive/expected/v2/cluster_version_mapping.json
+++ b/tests/build_tool/valid_comprehensive/expected/v2/cluster_version_mapping.json
@@ -1,7 +1,7 @@
 [
-    ["4.0.0", "config_minimal.json"],
-    ["4.1.0", "config_all_gathering_rules.json"],
-    ["4.2.0", "config_all_container_logs.json"],
-    ["4.3.0", "config_multiple_patterns.json"],
-    ["4.4.0", "config_duplicates.json"]
+    ["4.0.0", "remote_configurations/config_minimal.json"],
+    ["4.1.0", "remote_configurations/config_all_gathering_rules.json"],
+    ["4.2.0", "remote_configurations/config_all_container_logs.json"],
+    ["4.3.0", "remote_configurations/config_multiple_patterns.json"],
+    ["4.4.0", "remote_configurations/config_duplicates.json"]
 ]

--- a/tests/build_tool/valid_comprehensive/src/blueprints_v2/cluster_version_mapping.json
+++ b/tests/build_tool/valid_comprehensive/src/blueprints_v2/cluster_version_mapping.json
@@ -1,7 +1,7 @@
 [
-    ["4.0.0", "config_minimal.json"],
-    ["4.1.0", "config_all_gathering_rules.json"],
-    ["4.2.0", "config_all_container_logs.json"],
-    ["4.3.0", "config_multiple_patterns.json"],
-    ["4.4.0", "config_duplicates.json"]
+    ["4.0.0", "remote_configurations/config_minimal.json"],
+    ["4.1.0", "remote_configurations/config_all_gathering_rules.json"],
+    ["4.2.0", "remote_configurations/config_all_container_logs.json"],
+    ["4.3.0", "remote_configurations/config_multiple_patterns.json"],
+    ["4.4.0", "remote_configurations/config_duplicates.json"]
 ]

--- a/tests/build_tool/valid_v2_blueprint_paths/expected/v1/rules.json
+++ b/tests/build_tool/valid_v2_blueprint_paths/expected/v1/rules.json
@@ -1,0 +1,21 @@
+{
+  "rules": [
+    {
+      "conditions": [
+        {
+          "alert": {
+            "name": "KubePodCrashLooping"
+          },
+          "type": "alert_is_firing"
+        }
+      ],
+      "gathering_functions": {
+        "logs_of_namespace": {
+          "namespace": "openshift-extra",
+          "tail_lines": 100
+        }
+      }
+    }
+  ],
+  "version": "0.0.1"
+}

--- a/tests/build_tool/valid_v2_blueprint_paths/expected/v2/cluster_version_mapping.json
+++ b/tests/build_tool/valid_v2_blueprint_paths/expected/v2/cluster_version_mapping.json
@@ -1,0 +1,4 @@
+[
+    ["4.0.0", "remote_configurations_A/config_minimal.json"],
+    ["4.1.0", "remote_configurations_B/config_default.json"]
+]

--- a/tests/build_tool/valid_v2_blueprint_paths/expected/v2/remote_configurations_A/config_minimal.json
+++ b/tests/build_tool/valid_v2_blueprint_paths/expected/v2/remote_configurations_A/config_minimal.json
@@ -1,0 +1,22 @@
+{
+  "conditional_gathering_rules": [
+    {
+      "conditions": [
+        {
+          "alert": {
+            "name": "KubePodCrashLooping"
+          },
+          "type": "alert_is_firing"
+        }
+      ],
+      "gathering_functions": {
+        "logs_of_namespace": {
+          "namespace": "openshift-extra",
+          "tail_lines": 100
+        }
+      }
+    }
+  ],
+  "container_logs": [],
+  "version": "0.0.1"
+}

--- a/tests/build_tool/valid_v2_blueprint_paths/expected/v2/remote_configurations_B/config_default.json
+++ b/tests/build_tool/valid_v2_blueprint_paths/expected/v2/remote_configurations_B/config_default.json
@@ -1,0 +1,31 @@
+{
+  "conditional_gathering_rules": [
+    {
+      "conditions": [
+        {
+          "alert": {
+            "name": "KubePodCrashLooping"
+          },
+          "type": "alert_is_firing"
+        }
+      ],
+      "gathering_functions": {
+        "logs_of_namespace": {
+          "namespace": "openshift-extra",
+          "tail_lines": 100
+        }
+      }
+    }
+  ],
+  "container_logs": [
+    {
+      "messages": [
+        "sample message 1-1",
+        "sample message 1-2"
+      ],
+      "namespace": "openshift-sample-request-1",
+      "pod_name_regex": "pod-prefix-1-.*"
+    }
+  ],
+  "version": "0.0.1"
+}

--- a/tests/build_tool/valid_v2_blueprint_paths/src/blueprints_v1/rules.json
+++ b/tests/build_tool/valid_v2_blueprint_paths/src/blueprints_v1/rules.json
@@ -1,0 +1,5 @@
+{
+  "rules": [
+    "conditional_gathering_rules/*.json"
+  ]
+}

--- a/tests/build_tool/valid_v2_blueprint_paths/src/blueprints_v2/cluster_version_mapping.json
+++ b/tests/build_tool/valid_v2_blueprint_paths/src/blueprints_v2/cluster_version_mapping.json
@@ -1,0 +1,4 @@
+[
+    ["4.0.0", "remote_configurations_A/config_minimal.json"],
+    ["4.1.0", "remote_configurations_B/config_default.json"]
+]

--- a/tests/build_tool/valid_v2_blueprint_paths/src/blueprints_v2/remote_configurations_A/config_minimal.json
+++ b/tests/build_tool/valid_v2_blueprint_paths/src/blueprints_v2/remote_configurations_A/config_minimal.json
@@ -1,0 +1,6 @@
+{
+  "conditional_gathering_rules": [
+    "conditional_gathering_rules/sample_gathering_rule.json"
+  ],
+  "container_logs": []
+}

--- a/tests/build_tool/valid_v2_blueprint_paths/src/blueprints_v2/remote_configurations_B/config_default.json
+++ b/tests/build_tool/valid_v2_blueprint_paths/src/blueprints_v2/remote_configurations_B/config_default.json
@@ -1,0 +1,8 @@
+{
+  "conditional_gathering_rules": [
+    "conditional_gathering_rules/*.json"
+  ],
+  "container_logs": [
+    "container_log_requests/*.json"
+  ]
+}

--- a/tests/build_tool/valid_v2_blueprint_paths/src/conditional_gathering_rules/sample_gathering_rule.json
+++ b/tests/build_tool/valid_v2_blueprint_paths/src/conditional_gathering_rules/sample_gathering_rule.json
@@ -1,0 +1,16 @@
+{
+  "conditions": [
+    {
+      "alert": {
+        "name": "KubePodCrashLooping"
+      },
+      "type": "alert_is_firing"
+    }
+  ],
+  "gathering_functions": {
+    "logs_of_namespace": {
+      "namespace": "openshift-extra",
+      "tail_lines": 100
+    }
+  }
+}

--- a/tests/build_tool/valid_v2_blueprint_paths/src/container_log_requests/sample_request.json
+++ b/tests/build_tool/valid_v2_blueprint_paths/src/container_log_requests/sample_request.json
@@ -1,0 +1,8 @@
+{
+  "messages": [
+    "sample message 1-1",
+    "sample message 1-2"
+  ],
+  "namespace": "openshift-sample-request-1",
+  "pod_name_regex": "pod-prefix-1-.*"
+}

--- a/tests/source_data_validation/__init__.py
+++ b/tests/source_data_validation/__init__.py
@@ -6,11 +6,11 @@ CONTAINER_LOG_REQUESTS_DIR = PROJECT_ROOT / "container_log_requests"
 
 GATHERING_RULES_DIR = PROJECT_ROOT / "conditional_gathering_rules"
 
-REMOTE_CONFIGURATIONS_V2_BLUEPRINT_DIR = PROJECT_ROOT / "blueprints_v2" / "remote_configurations"
+BLUEPRINTS_V2_DIR = PROJECT_ROOT / "blueprints_v2"
 
 
 def remote_configurations():
-    return REMOTE_CONFIGURATIONS_V2_BLUEPRINT_DIR.glob("*.json")
+    return BLUEPRINTS_V2_DIR.glob("remote_configurations/*.json")
 
 
 def gathering_rules():

--- a/tests/source_data_validation/test_conditions.py
+++ b/tests/source_data_validation/test_conditions.py
@@ -4,9 +4,9 @@ import pathlib
 import pytest
 
 from tests.source_data_validation import (
+    BLUEPRINTS_V2_DIR,
     CLUSTER_MAPPING_PATH,
     PROJECT_ROOT,
-    REMOTE_CONFIGURATIONS_V2_BLUEPRINT_DIR,
     container_log_requests,
     gathering_rules,
     remote_configurations,
@@ -16,11 +16,9 @@ from tests.source_data_validation import (
 @pytest.mark.parametrize("remote_config_path", remote_configurations())
 def test_all_remote_configurations_used(remote_config_path):
     mapping = json.loads(CLUSTER_MAPPING_PATH.read_text())
-    mapping_configs = [pair[1] for pair in mapping]
+    mapping_configs = [relpath for _, relpath in mapping]
 
-    relative_config_path = str(
-        remote_config_path.relative_to(REMOTE_CONFIGURATIONS_V2_BLUEPRINT_DIR)
-    )
+    relative_config_path = str(remote_config_path.relative_to(BLUEPRINTS_V2_DIR))
     assert relative_config_path in mapping_configs
 
 


### PR DESCRIPTION
As agreed, changing the `cluster_version_mapping.json` file to use relative paths to reference remote configurations instead of just file names.

I tried to break the change into small steps. See individual commits:

* A bunch of commits refactor `build.py` to make the change simple. These commits deliberately do not change tests.
* The last commit makes the actual change in `build.py` behavior.  It is the only commit where tests change.

I still need to add a check to make sure the relative paths do not point outside of the parent directory of the file. Tests in `tests/source_data_validation` might deserve more changes, too. I will do that after this PR.