### PR TITLE
Make sure all v2 blueprints are under the blueprints_v2 directory

### DIFF
--- a/tests/build_tool/invalid_cluster_version_mapping_relpath/expected_stderr.txt
+++ b/tests/build_tool/invalid_cluster_version_mapping_relpath/expected_stderr.txt
@@ -1,0 +1,2 @@
+src/blueprints_v2/cluster_version_mapping.json
+ClusterVersionMappingError: '../config_not_allowed.json' does not reference a valid config at index 1

--- a/tests/build_tool/invalid_cluster_version_mapping_relpath/expected_stdout.txt
+++ b/tests/build_tool/invalid_cluster_version_mapping_relpath/expected_stdout.txt
@@ -1,0 +1,1 @@
+ClusterVersionMappingError: '../config_not_allowed.json' does not reference a valid config at index 1

--- a/tests/build_tool/invalid_cluster_version_mapping_relpath/src/blueprints_v1/rules.json
+++ b/tests/build_tool/invalid_cluster_version_mapping_relpath/src/blueprints_v1/rules.json
@@ -1,0 +1,5 @@
+{
+  "rules": [
+    "conditional_gathering_rules/*.json"
+  ]
+}

--- a/tests/build_tool/invalid_cluster_version_mapping_relpath/src/blueprints_v2/cluster_version_mapping.json
+++ b/tests/build_tool/invalid_cluster_version_mapping_relpath/src/blueprints_v2/cluster_version_mapping.json
@@ -1,0 +1,4 @@
+[
+    ["4.0.0", "remote_configurations/config_default.json"],
+    ["4.11.0", "../config_not_allowed.json"]
+]

--- a/tests/build_tool/invalid_cluster_version_mapping_relpath/src/blueprints_v2/remote_configurations/config_default.json
+++ b/tests/build_tool/invalid_cluster_version_mapping_relpath/src/blueprints_v2/remote_configurations/config_default.json
@@ -1,0 +1,6 @@
+{
+  "conditional_gathering_rules": [
+    "conditional_gathering_rules/valid.json"
+  ],
+  "container_logs": []
+}

--- a/tests/build_tool/invalid_cluster_version_mapping_relpath/src/conditional_gathering_rules/valid.json
+++ b/tests/build_tool/invalid_cluster_version_mapping_relpath/src/conditional_gathering_rules/valid.json
@@ -1,0 +1,16 @@
+{
+  "conditions": [
+    {
+      "alert": {
+        "name": "KubePodCrashLooping"
+      },
+      "type": "alert_is_firing"
+    }
+  ],
+  "gathering_functions": {
+    "logs_of_namespace": {
+      "namespace": "openshift-sample-a2",
+      "tail_lines": 100
+    }
+  }
+}

--- a/tests/build_tool/invalid_cluster_version_mapping_relpath/src/config_not_allowed.json
+++ b/tests/build_tool/invalid_cluster_version_mapping_relpath/src/config_not_allowed.json
@@ -1,0 +1,6 @@
+{
+  "conditional_gathering_rules": [
+    "conditional_gathering_rules/valid.json"
+  ],
+  "container_logs": []
+}


### PR DESCRIPTION
The 'cluster_version_mapping.json' file references v2 remote configuration blueprints using relative paths. This commit makes sure that the relative paths do not "escape" the parent directory of the 'cluster_version_mapping.json' file.