### PR TITLE
OCPBUGS-63248: add conditional rule for PrometheusRemoteStorageFailur…

### DIFF
--- a/conditional_gathering_rules/PrometheusRemoteStorageFailures.json
+++ b/conditional_gathering_rules/PrometheusRemoteStorageFailures.json
@@ -1,0 +1,17 @@
+{
+  "conditions": [
+    {
+      "alert": {
+        "name": "PrometheusRemoteStorageFailures"
+      },
+      "type": "alert_is_firing"
+    }
+  ],
+  "gathering_functions": {
+    "containers_logs": {
+      "alert_name": "PrometheusRemoteStorageFailures",
+      "container": "prometheus",
+      "tail_lines": 100
+    }
+  }
+}


### PR DESCRIPTION
…es alert

This commit adds a conditional gathering rule when the PrometheusRemoteStorageFailures alert fires to help us troubleshoot https://issues.redhat.com/browse/OCPBUGS-63248.