### PR TITLE
Add Codecov coverage reporting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,4 +28,12 @@ jobs:
           pip3 install -r requirements.txt
       - name: Test
         run: |
-          pytest
+          pytest --cov=. --cov-report=xml:coverage.xml
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: unit-tests
+          files: coverage.xml
+          fail_ci_if_error: false


### PR DESCRIPTION
## Summary

- Add `--cov=. --cov-report=xml:coverage.xml` to the `pytest` invocation in `ci.yaml`
- Add `codecov/codecov-action@v5` upload step with `unit-tests` flag after tests pass

## Test plan

- [x] CI passes on this PR
- [x] Coverage report appears in [app.codecov.io](https://app.codecov.io) for this repo
- [x] `unit-tests` flag visible under the Flags tab in Codecov UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)